### PR TITLE
* : support disable TC probes in egress when interface was loopback (#18)

### DIFF
--- a/err.go
+++ b/err.go
@@ -26,4 +26,5 @@ var (
 	ErrMapInitialized          = errors.New("map already initialized")
 	ErrMapNotInitialized       = errors.New("the map must be initialized first")
 	ErrMapNotRunning           = errors.New("the map is not running")
+	ErrLoopbackDisabled        = errors.New("loopback is disabled")
 )

--- a/examples/programs/tc/main.go
+++ b/examples/programs/tc/main.go
@@ -12,6 +12,7 @@ var m = &manager.Manager{
 			EbpfFuncName:     "egress_cls_func",
 			Ifname:           "eth0", // change this to the interface connected to the internet
 			NetworkDirection: manager.Egress,
+			SkipLoopback:     true,
 		},
 		{
 			Section:          "classifier/ingress",


### PR DESCRIPTION
feature : support disable TC probes in egress when interface was loopback (#18)

Signed-off-by: CFC4N <cfc4n.cs@gmail.com>