### PR TITLE
Use /proc/kallsyms for kprobe/kretprobe function name search. (fixes #30)

### DIFF
--- a/probe.go
+++ b/probe.go
@@ -373,24 +373,16 @@ func (p *Probe) init() error {
 	}
 
 	// Find function name match if required
-	var kProbe = false
 	if strings.HasPrefix(p.Section, "kretprobe/") || (strings.HasPrefix(p.Section, "kprobe/")) {
-		var err error
-		p.funcName, err = FindFilterFunction(p.Section)
-		if err != nil {
-			p.lastError = err
-			return err
-		}
-		kProbe = true
-	}
-
-	if kProbe {
 		// Update syscall function name with the correct arch prefix
-		var err error
 		p.funcName, err = GetSyscallFnNameWithSymFile(p.AttachToFuncName, p.manager.options.SymFile)
 		if err != nil {
 			p.lastError = err
-			return err
+			p.funcName, err = FindFilterFunction(p.Section)
+			if err != nil {
+				p.lastError = err
+				return err
+			}
 		}
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,6 @@ import (
 	"debug/elf"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"runtime"
@@ -56,7 +55,7 @@ func FindFilterFunction(funcName string) (string, error) {
 
 	// Cache available filter functions if necessary
 	if len(availableFilterFunctions) == 0 {
-		funcs, err := ioutil.ReadFile("/sys/kernel/debug/tracing/available_filter_functions")
+		funcs, err := os.ReadFile("/sys/kernel/debug/tracing/available_filter_functions")
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
refer: https://github.com/iovisor/bcc/pull/1540